### PR TITLE
Various improvements to the Terraform examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ terraform.tfstate.*
 *.logs
 *.lock.hcl
 .env
+.terraform.tfstate.lock.info

--- a/README.md
+++ b/README.md
@@ -129,3 +129,11 @@ aad_tenant_id="AZURE_Tenant_id"
 1. Do I want managed or unmanaged OIDC providers?
 
 The managed OIDC provider creates the underlying resources in a Red Hat account, which you can consume. An unmanaged OIDC provider creates the underlying resources in your own account. If you are unsure, starting with Managed is probably easier.
+
+2. I'm getting this error, what do I do?
+
+```
+│ Error: either a token, an user name and password or a client identifier and secret are necessary, but none has been provided
+```
+
+Please export your RHCS_TOKEN as an environment variable, you can get this from https://console.redhat.com/openshift/token/rosa

--- a/README.md
+++ b/README.md
@@ -16,10 +16,8 @@ Variables can be passed to terraform using either Environment variables or using
 
 Following example shows how to configure common terraform environment variables.
    ```bash
-   export TF_VAR_url="https://api.openshift.com"
-   export TF_LOG="DEBUG"
-   export TF_LOG_PATH="logs/terraform.log"
    export RHCS_TOKEN="OCM TOKEN Value"
+   export TF_VAR_cluster_name="$Your_cluster_name"
    ```
 
 ### Usage
@@ -47,16 +45,11 @@ You can use the example in the ./rosa_sts_unmanaged_oidc directory to make a ROS
 
 ### Sample terraform.tfvars file for the Public ROSA STS Cluster
 ```
-token="OCM TOKEN Value"
-url="https://api.openshift.com"
 # Module selection
 create_vpc=false
-create_aad_app=false
-create_idp_aad=false
-create_account_roles=false
+create_account_roles=true
+create_operator_roles=true
 #ROSA Cluster Info
-account_role_prefix="ManagedOpenShift"
-operator_role_prefix="mobbtf"
 cluster_name="mobbtf-01"
 multi_az=true
 #AWS Info
@@ -70,22 +63,14 @@ additional_tags={
      TFOwner = "mobb@redhat.com"
      ROSAClusterName="mobbtf-01"
    }
-#Azure AD app reg Info
-aad_tenant_id="AZURE_Tenant_id"
 ```
 
 ## Sample terraform.tfvars file for the Private Link ROSA STS Cluster
 ```
-token="OCM TOKEN Value"
-url="https://api.openshift.com"
-# Module selection
 create_vpc=true
-create_aad_app=false
-create_idp_aad=false
-create_account_roles=false
+create_account_roles=true
+create_operator_roles=true
 #ROSA Cluster Info
-account_role_prefix="ManagedOpenShift"
-operator_role_prefix="mobbtf"
 cluster_name="mobbtf-01"
 multi_az=true
 #AWS Info
@@ -102,8 +87,6 @@ additional_tags={
      TFOwner = "mobb@redhat.com"
      ROSAClusterName="mobbtf-01"
    }
-#Azure AD app reg Info
-aad_tenant_id="AZURE_Tenant_id"
 ```
 
 ## Deploy
@@ -145,3 +128,7 @@ The managed OIDC provider creates the underlying resources in a Red Hat account,
 ```
 
 Please export your RHCS_TOKEN as an environment variable, you can get this from https://console.redhat.com/openshift/token/rosa
+
+3. Why is my cluster name something random like rosa-233is?
+
+A random name is generated for your cluster if you do not provide the variable `cluster_name`

--- a/modules/rosa_cluster/main.tf
+++ b/modules/rosa_cluster/main.tf
@@ -41,6 +41,13 @@ resource "rhcs_cluster_rosa_classic" "rosa_sts_cluster" {
   aws_subnet_ids   = var.aws_subnet_ids
   machine_cidr     = var.enable_private_link ? var.vpc_cidr_block : null
 
+  lifecycle {
+    precondition {
+      condition     = can(regex("^[a-z][-a-z0-9]{0,13}[a-z0-9]$", var.cluster_name))
+      error_message = "ROSA cluster name must be less than 16 characters, be lower case alphanumeric, with only hyphens."
+    }
+  }
+
 }
 
 resource "rhcs_cluster_wait" "rosa_cluster" {

--- a/modules/rosa_cluster/output.tf
+++ b/modules/rosa_cluster/output.tf
@@ -10,7 +10,6 @@ output "oidc_endpoint_url" {
   value = rhcs_cluster_rosa_classic.rosa_sts_cluster.sts.oidc_endpoint_url
 }
 
-/*
-output cluster_dns {
-   value = ocm_cluster_rosa_classic.rosa_sts_cluster.dns
-}*/
+output domain {
+   value = rhcs_cluster_rosa_classic.rosa_sts_cluster.domain
+}

--- a/rosa_sts_managed_oidc/main.tf
+++ b/rosa_sts_managed_oidc/main.tf
@@ -14,15 +14,26 @@
 # limitations under the License.
 #
 
+data "aws_availability_zones" "available" {}
+
+locals {
+  # Extract availability zone names for the specified region
+  region_azs = [for zone in data.aws_availability_zones.available.names : format("%s", zone)]
+}
+
+output "availability_zones" {
+  value = local.region_azs
+}
+
 # Create the VPC if it is wanted
 module "vpc" {
   create_vpc           = var.create_vpc
   source               = "../modules/network"
   aws_region           = var.aws_region
-  vpc_name             = var.vpc_name
+  vpc_name             = "${var.cluster_name}_vpc"
   additional_tags      = var.additional_tags
   vpc_cidr_block       = var.vpc_cidr_block
-  availability_zones   = var.availability_zones
+  availability_zones   = local.region_azs
   private_subnet_cidrs = var.private_subnet_cidrs
   public_subnet_cidrs  = var.public_subnet_cidrs
   single_nat_gateway   = var.single_nat_gateway
@@ -32,7 +43,7 @@ module "vpc" {
 module "account_role" {
   create_account_roles   = var.create_account_roles
   source                 = "../modules/account_roles"
-  account_role_prefix    = var.account_role_prefix
+  account_role_prefix    = var.cluster_name
   path                   = var.path
   rosa_openshift_version = var.rosa_openshift_version
   account_role_policies  = var.account_role_policies
@@ -51,8 +62,8 @@ resource "time_sleep" "wait_10_seconds" {
 # Create managed OIDC config
 module "oidc_provider" {
   source               = "../modules/managed_oidc_provider"
-  operator_role_prefix = var.operator_role_prefix
-  account_role_prefix  = var.account_role_prefix
+  operator_role_prefix = var.cluster_name
+  account_role_prefix  = var.cluster_name
   additional_tags      = var.additional_tags
   path                 = var.path
   # We need the account role to be created before we can make the OIDC provider
@@ -62,11 +73,11 @@ module "oidc_provider" {
 # Create the operator roles for ROSA
 module "operator_roles" {
   create_operator_roles = var.create_operator_roles
-  source               = "../modules/operator_roles"
+  source                = "../modules/operator_roles"
   oidc_thumbprint       = module.oidc_provider.thumbprint
   oidc_endpoint_url     = module.oidc_provider.oidc_endpoint_url
-  operator_role_prefix = var.operator_role_prefix
-  additional_tags      = var.additional_tags
+  operator_role_prefix  = var.cluster_name
+  additional_tags       = var.additional_tags
 }
 
 # Make the ROSA Cluster
@@ -76,21 +87,20 @@ module "rosa_cluster" {
   rosa_openshift_version = var.rosa_openshift_version
   aws_region             = var.aws_region
   multi_az               = var.multi_az
-  availability_zones     = var.availability_zones
-  account_role_prefix    = var.account_role_prefix
-  operator_role_prefix   = var.operator_role_prefix
+  availability_zones     = local.region_azs
+  account_role_prefix    = var.cluster_name
+  operator_role_prefix   = var.cluster_name
   machine_type           = var.machine_type
   proxy                  = var.proxy
   autoscaling_enabled    = var.autoscaling_enabled
-  min_replicas           = var.min_replicas
-  max_replicas           = var.max_replicas
+  worker_node_replicas   = var.worker_node_replicas
   oidc_config_id         = module.oidc_provider.id
   additional_tags        = var.additional_tags
   vpc_cidr_block         = var.vpc_cidr_block
 
   #private link cluster values
-  enable_private_link = var.enable_private_link
-  aws_subnet_ids   = var.create_vpc ? module.vpc.private_subnets : var.aws_subnet_ids
+  enable_private_link = var.private_cluster
+  aws_subnet_ids      = var.create_vpc ? concat(module.vpc.public_subnets, module.vpc.private_subnets) : var.aws_subnet_ids
 
   depends_on = [time_sleep.wait_10_seconds]
 }

--- a/rosa_sts_managed_oidc/variables.tf
+++ b/rosa_sts_managed_oidc/variables.tf
@@ -44,18 +44,13 @@ variable "create_operator_roles" {
 variable "create_vpc" {
   type        = bool
   description = "Create custom VPC for ROSA cluster"
-  default     = true
 }
 
 # ROSA Cluster info
 variable "cluster_name" {
   type        = string
   description = "The name of the ROSA cluster to create"
-
-  validation {
-    condition     = can(regex("^[a-z][-a-z0-9]{0,13}[a-z0-9]$", var.cluster_name))
-    error_message = "ROSA cluster name must be less than 16 characters, be lower case alphanumeric, with only hyphens."
-  }
+  default     = null
 }
 
 variable "additional_tags" {
@@ -161,4 +156,5 @@ variable "single_nat_gateway" {
 #AWS Info
 variable "aws_region" {
   type    = string
+  default = "eu-west-1"
 }

--- a/rosa_sts_managed_oidc/variables.tf
+++ b/rosa_sts_managed_oidc/variables.tf
@@ -1,13 +1,7 @@
 variable "rosa_openshift_version" {
   type        = string
-  default     = "4.13"
+  default     = "4.14.2"
   description = "Desired version of OpenShift for the cluster, for example '4.1.0'. If version is greater than the currently running version, an upgrade will be scheduled."
-}
-
-# Account Roles
-variable "account_role_prefix" {
-  type    = string
-  default = "mobb"
 }
 
 variable "account_role_policies" {
@@ -19,36 +13,6 @@ variable "account_role_policies" {
     sts_instance_controlplane_permission_policy = string
   })
   default = null
-}
-
-# Used ?
-variable "rh_oidc_provider_thumbprint" {
-  description = "Thumbprint for https://rh-oidc.s3.us-east-1.amazonaws.com"
-  type        = string
-  default     = "917e732d330f9a12404f73d8bea36948b929dffc"
-}
-
-variable "all_versions" {
-  description = "OpenShift versions"
-  type = object({
-    item = object({
-      id   = string
-      name = string
-    })
-    search = string
-    order  = string
-    items = list(object({
-      id   = string
-      name = string
-    }))
-  })
-  default = null
-}
-
-# Operrator Roles
-variable "operator_role_prefix" {
-  type    = string
-  default = "mobbtf"
 }
 
 variable "operator_role_policies" {
@@ -68,44 +32,25 @@ variable "operator_role_policies" {
 variable "create_account_roles" {
   type        = bool
   description = "Create cluster wide accounts roles"
-  default     = false
+  default     = true
 }
 
 variable "create_operator_roles" {
   type        = bool
   description = "Create cluster wide operator roles"
-  default     = false
+  default     = true
 }
 
 variable "create_vpc" {
   type        = bool
   description = "Create custom VPC for ROSA cluster"
-  default     = false
-}
-
-variable "managed_oidc" {
-  type        = bool
-  description = "Red Hat managed or unmanaged (Customer hosted) OIDC Configuration"
   default     = true
-}
-
-variable "create_aad_app" {
-  type        = bool
-  description = "Create a Azure AD app for ROSA cluster idp"
-  default     = false
-}
-
-variable "create_idp_aad" {
-  type        = bool
-  description = "Create Azure AD IDP for ROSA cluster"
-  default     = false
 }
 
 # ROSA Cluster info
 variable "cluster_name" {
   type        = string
   description = "The name of the ROSA cluster to create"
-  default     = "mobb-tf"
 
   validation {
     condition     = can(regex("^[a-z][-a-z0-9]{0,13}[a-z0-9]$", var.cluster_name))
@@ -132,16 +77,17 @@ variable "path" {
 variable "multi_az" {
   type        = bool
   description = "Multi AZ Cluster for High Availability"
-  default     = false
+  default     = true
 }
 
 variable "machine_type" {
   description = "The AWS instance type that used for the instances creation ."
   type        = string
+  default     = "m5.xlarge"
 }
 
 variable "worker_node_replicas" {
-  default     = null
+  default     = 3
   description = "Number of worker nodes to provision. Single zone clusters need at least 2 nodes, multizone clusters need at least 3 nodes"
   type        = number
 }
@@ -156,13 +102,13 @@ variable "autoscaling_enabled" {
 variable "min_replicas" {
   description = "The minimum number of replicas for autoscaling."
   type        = number
-  default     = null
+  default     = 3
 }
 
 variable "max_replicas" {
   description = "The maximum number of replicas not exceeded by the autoscaling functionality."
   type        = number
-  default     = null
+  default     = 3
 }
 
 variable "proxy" {
@@ -177,17 +123,9 @@ variable "proxy" {
 }
 
 #Private link cluster Info
-variable "enable_private_link" {
+variable "private_cluster" {
   type        = bool
-  description = "This enables private link"
-  default     = false
-}
-
-#VPC Info
-variable "vpc_name" {
-  type        = string
-  description = "VPC Name"
-  default     = "mobb-tf-vpc"
+  description = "Do you want this cluster to be private? true or false"
 }
 
 variable "vpc_cidr_block" {
@@ -223,61 +161,4 @@ variable "single_nat_gateway" {
 #AWS Info
 variable "aws_region" {
   type    = string
-  default = "us-east-2"
-}
-
-variable "availability_zones" {
-  type        = list(any)
-  description = "The availability zones to use for the cluster"
-  default     = ["us-east-2a", "us-east-2b", "us-east-2c"]
-}
-
-#Azure AD config
-variable "aad_app_name" {
-  type        = string
-  default     = "kumudu-tf-test-app"
-  description = "Azure AD App Name"
-}
-
-variable "aad_app_password_name" {
-  type        = string
-  default     = "kh-ROSA-Secret"
-  description = "AAD Secret Name"
-}
-
-variable "aad_app_redirect_uri" {
-  type        = string
-  default     = "https://oauth-openshift.apps.iv2wbc7f.westus2.aroapp.io/oauth2callback/AAD"
-  description = "AAD App Redirect_uri"
-}
-
-variable "aad_location" {
-  type        = string
-  default     = "eastus"
-  description = "Azure region"
-}
-
-#IDP
-variable "idp_name" {
-  type    = string
-  default = "AAD"
-}
-
-variable "aad_client_id" {
-  description = "Azure Application (client) ID"
-  default     = "known"
-  type        = string
-}
-
-variable "aad_client_secret" {
-  description = "Azure Client credentials"
-  default     = "known"
-  type        = string
-  sensitive   = true
-}
-
-variable "aad_tenant_id" {
-  description = "Azure Directory (tenant) ID"
-  type        = string
-  sensitive   = true
 }

--- a/rosa_sts_managed_oidc_no_modules/account-roles.tf
+++ b/rosa_sts_managed_oidc_no_modules/account-roles.tf
@@ -9,7 +9,7 @@ module "create_account_roles" {
   create_account_roles  = true
   create_operator_roles = false
 
-  account_role_prefix    = var.account_role_prefix
+  account_role_prefix    = var.cluster_name
   path                   = var.path
   rosa_openshift_version = regex("^[0-9]+\\.[0-9]+", var.rosa_openshift_version)
   account_role_policies  = data.rhcs_policies.all_policies.account_role_policies

--- a/rosa_sts_managed_oidc_no_modules/account-roles.tf
+++ b/rosa_sts_managed_oidc_no_modules/account-roles.tf
@@ -9,7 +9,7 @@ module "create_account_roles" {
   create_account_roles  = true
   create_operator_roles = false
 
-  account_role_prefix    = var.cluster_name
+  account_role_prefix    = local.cluster_name
   path                   = var.path
   rosa_openshift_version = regex("^[0-9]+\\.[0-9]+", var.rosa_openshift_version)
   account_role_policies  = data.rhcs_policies.all_policies.account_role_policies

--- a/rosa_sts_managed_oidc_no_modules/oidc-provider.tf
+++ b/rosa_sts_managed_oidc_no_modules/oidc-provider.tf
@@ -3,8 +3,8 @@ resource "rhcs_rosa_oidc_config" "oidc_config" {
 }
 
 data "rhcs_rosa_operator_roles" "operator_roles" {
-  operator_role_prefix = var.cluster_name
-  account_role_prefix  = var.cluster_name
+  operator_role_prefix = local.cluster_name
+  account_role_prefix  = local.cluster_name
 }
 
 module "oidc_provider" {

--- a/rosa_sts_managed_oidc_no_modules/oidc-provider.tf
+++ b/rosa_sts_managed_oidc_no_modules/oidc-provider.tf
@@ -3,8 +3,8 @@ resource "rhcs_rosa_oidc_config" "oidc_config" {
 }
 
 data "rhcs_rosa_operator_roles" "operator_roles" {
-  operator_role_prefix = var.operator_role_prefix
-  account_role_prefix  = var.account_role_prefix
+  operator_role_prefix = var.cluster_name
+  account_role_prefix  = var.cluster_name
 }
 
 module "oidc_provider" {

--- a/rosa_sts_managed_oidc_no_modules/rosa-cluster.tf
+++ b/rosa_sts_managed_oidc_no_modules/rosa-cluster.tf
@@ -1,13 +1,24 @@
+data "aws_availability_zones" "available" {}
+
+locals {
+  # Extract availability zone names for the specified region
+  region_azs = [for zone in data.aws_availability_zones.available.names : format("%s", zone)]
+}
+
+output "availability_zones" {
+  value = local.region_azs
+}
+
 locals {
   path = coalesce(var.path, "/")
   sts_roles = {
-    role_arn         = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${local.path}${var.account_role_prefix}-Installer-Role",
-    support_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${local.path}${var.account_role_prefix}-Support-Role",
+    role_arn         = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${local.path}${var.cluster_name}-Installer-Role",
+    support_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${local.path}${var.cluster_name}-Support-Role",
     instance_iam_roles = {
-      master_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${local.path}${var.account_role_prefix}-ControlPlane-Role",
-      worker_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${local.path}${var.account_role_prefix}-Worker-Role"
+      master_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${local.path}${var.cluster_name}-ControlPlane-Role",
+      worker_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${local.path}${var.cluster_name}-Worker-Role"
     },
-    operator_role_prefix = var.operator_role_prefix,
+    operator_role_prefix = var.cluster_name,
     oidc_config_id       = rhcs_rosa_oidc_config.oidc_config.id
   }
   worker_node_replicas = try(var.worker_node_replicas, var.multi_az ? 3 : 2)
@@ -21,24 +32,24 @@ resource "rhcs_cluster_rosa_classic" "rosa_sts_cluster" {
   cloud_region         = var.aws_region
   multi_az             = var.multi_az
   aws_account_id       = data.aws_caller_identity.current.account_id
-  availability_zones   = var.availability_zones
+  availability_zones   = local.region_azs
   tags                 = var.additional_tags
   version              = var.rosa_openshift_version
   proxy                = var.proxy
   compute_machine_type = var.machine_type
   replicas             = local.worker_node_replicas
   autoscaling_enabled  = var.autoscaling_enabled
-  min_replicas         = var.min_replicas
-  max_replicas         = var.max_replicas
+  # Uncomment if autoscaling enabled
+  #min_replicas         = var.min_replicas
+  #max_replicas         = var.max_replicas
   sts                  = local.sts_roles
   properties = {
     rosa_creator_arn = data.aws_caller_identity.current.arn
   }
   #Private link settings
-  private          = var.enable_private_link
-  aws_private_link = var.enable_private_link
-  aws_subnet_ids   = var.create_vpc ? module.vpc[0].private_subnets : var.private_subnet_ids
-  machine_cidr     = var.enable_private_link ? var.vpc_cidr_block : null
+  aws_private_link = var.private_cluster
+  aws_subnet_ids   = var.create_vpc ? concat(module.vpc[0].private_subnets, module.vpc[0].public_subnets) : var.private_subnet_ids
+  machine_cidr     = var.private_cluster ? var.vpc_cidr_block : null
 
   depends_on = [module.create_account_roles]
 }

--- a/rosa_sts_managed_oidc_no_modules/rosa-cluster.tf
+++ b/rosa_sts_managed_oidc_no_modules/rosa-cluster.tf
@@ -1,34 +1,38 @@
 data "aws_availability_zones" "available" {}
 
 locals {
-  # Extract availability zone names for the specified region
-  region_azs = [for zone in data.aws_availability_zones.available.names : format("%s", zone)]
+  # Extract availability zone names for the specified region, limit it to 3
+  region_azs = slice([for zone in data.aws_availability_zones.available.names : format("%s", zone)], 0, 3)
 }
 
-output "availability_zones" {
-  value = local.region_azs
+resource "random_string" "random_name" {
+  length           = 6
+  special          = false
+  upper            = false
 }
 
 locals {
   path = coalesce(var.path, "/")
   sts_roles = {
-    role_arn         = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${local.path}${var.cluster_name}-Installer-Role",
-    support_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${local.path}${var.cluster_name}-Support-Role",
+    role_arn         = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${local.path}${local.cluster_name}-Installer-Role",
+    support_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${local.path}${local.cluster_name}-Support-Role",
     instance_iam_roles = {
-      master_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${local.path}${var.cluster_name}-ControlPlane-Role",
-      worker_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${local.path}${var.cluster_name}-Worker-Role"
+      master_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${local.path}${local.cluster_name}-ControlPlane-Role",
+      worker_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${local.path}${local.cluster_name}-Worker-Role"
     },
-    operator_role_prefix = var.cluster_name,
+    operator_role_prefix = local.cluster_name,
     oidc_config_id       = rhcs_rosa_oidc_config.oidc_config.id
   }
   worker_node_replicas = try(var.worker_node_replicas, var.multi_az ? 3 : 2)
+  # If cluster_name is not null, use that, otherwise generate a random cluster name
+  cluster_name = coalesce(var.cluster_name, "rosa-${random_string.random_name.result}")
 }
 
 data "aws_caller_identity" "current" {
 }
 
 resource "rhcs_cluster_rosa_classic" "rosa_sts_cluster" {
-  name                 = var.cluster_name
+  name                 = local.cluster_name
   cloud_region         = var.aws_region
   multi_az             = var.multi_az
   aws_account_id       = data.aws_caller_identity.current.account_id
@@ -52,6 +56,13 @@ resource "rhcs_cluster_rosa_classic" "rosa_sts_cluster" {
   aws_private_link = var.enable_private_link
   aws_subnet_ids   = var.create_vpc ? concat(module.vpc[0].private_subnets, module.vpc[0].public_subnets) : var.private_subnet_ids
   machine_cidr     = var.enable_private_link ? var.vpc_cidr_block : null
+
+  lifecycle {
+    precondition {
+      condition     = can(regex("^[a-z][-a-z0-9]{0,13}[a-z0-9]$", local.cluster_name))
+      error_message = "ROSA cluster name must be less than 16 characters, be lower case alphanumeric, with only hyphens."
+    }
+  }
 
   depends_on = [module.create_account_roles]
 }

--- a/rosa_sts_managed_oidc_no_modules/terraform.tfvars.bak
+++ b/rosa_sts_managed_oidc_no_modules/terraform.tfvars.bak
@@ -32,7 +32,7 @@ additional_tags={
 
 #Private Link Cluster & VPC
 single_nat_gateway=true 
-enable_private_link=true
+#enable_private_link=true
 vpc_cidr_block="10.12.0.0/16"
 private_subnet_cidrs=["10.12.0.0/22", "10.12.4.0/22", "10.12.8.0/22"]
 public_subnet_cidrs=["10.12.128.0/24", "10.12.129.0/24", "10.12.130.0/24"]

--- a/rosa_sts_managed_oidc_no_modules/variables.tf
+++ b/rosa_sts_managed_oidc_no_modules/variables.tf
@@ -35,13 +35,9 @@ variable "create_vpc" {
 
 # ROSA Cluster info
 variable "cluster_name" {
+  default     = null
   type        = string
   description = "The name of the ROSA cluster to create"
-
-  validation {
-    condition     = can(regex("^[a-z][-a-z0-9]{0,13}[a-z0-9]$", var.cluster_name))
-    error_message = "ROSA cluster name must be less than 16 characters, be lower case alphanumeric, with only hyphens."
-  }
 }
 
 variable "additional_tags" {

--- a/rosa_sts_managed_oidc_no_modules/variables.tf
+++ b/rosa_sts_managed_oidc_no_modules/variables.tf
@@ -1,13 +1,7 @@
 variable "rosa_openshift_version" {
   type        = string
-  default     = "4.13"
+  default     = "4.14.2"
   description = "Desired version of OpenShift for the cluster, for example '4.1.0'. If version is greater than the currently running version, an upgrade will be scheduled."
-}
-
-# Account Roles
-variable "account_role_prefix" {
-  type    = string
-  default = "mobb"
 }
 
 variable "account_role_policies" {
@@ -19,12 +13,6 @@ variable "account_role_policies" {
     sts_instance_controlplane_permission_policy = string
   })
   default = null
-}
-
-# Operator Roles
-variable "operator_role_prefix" {
-  type    = string
-  default = "mobbtf"
 }
 
 variable "operator_role_policies" {
@@ -42,20 +30,13 @@ variable "operator_role_policies" {
 
 variable "create_vpc" {
   type        = bool
-  description = "Create custom VPC for ROSA cluster"
-}
-
-variable "managed_oidc" {
-  type        = bool
-  description = "Red Hat managed or unmanaged (Customer hosted) OIDC Configuration"
-  default     = true
+  description = "Would you like to make a new VPC for your ROSA cluster? true or false"
 }
 
 # ROSA Cluster info
 variable "cluster_name" {
   type        = string
   description = "The name of the ROSA cluster to create"
-  default     = "poc-andyr"
 
   validation {
     condition     = can(regex("^[a-z][-a-z0-9]{0,13}[a-z0-9]$", var.cluster_name))
@@ -82,17 +63,17 @@ variable "path" {
 variable "multi_az" {
   type        = bool
   description = "Multi AZ Cluster for High Availability"
-  default     = false
+  default     = true
 }
 
 variable "machine_type" {
-  description = "The AWS instance type that used for the instances creation ."
+  description = "The AWS instance type used for your default worker pool"
   type        = string
   default     = "m5.xlarge"
 }
 
 variable "worker_node_replicas" {
-  default     = null
+  default     = 3
   description = "Number of worker nodes to provision. Single zone clusters need at least 2 nodes, multizone clusters need at least 3 nodes"
   type        = number
 }
@@ -107,13 +88,13 @@ variable "autoscaling_enabled" {
 variable "min_replicas" {
   description = "The minimum number of replicas for autoscaling."
   type        = number
-  default     = null
+  default     = 3
 }
 
 variable "max_replicas" {
   description = "The maximum number of replicas not exceeded by the autoscaling functionality."
   type        = number
-  default     = null
+  default     = 3
 }
 
 variable "proxy" {
@@ -127,11 +108,9 @@ variable "proxy" {
   })
 }
 
-#Private link cluster Info
-variable "enable_private_link" {
+variable "private_cluster" {
   type        = bool
-  description = "This enables private link"
-  default     = false
+  description = "Do you want this cluster to be private? true or false"
 }
 
 #VPC Info
@@ -169,19 +148,6 @@ variable "single_nat_gateway" {
 variable "aws_region" {
   type    = string
   default = "us-east-2"
-}
-
-variable "availability_zones" {
-  type        = list(any)
-  description = "The availability zones to use for the cluster"
-  default     = ["us-east-2a", "us-east-2b", "us-east-2c"]
-}
-
-
-variable "installer_role_arn" {
-  description = "STS Role ARN with get secrets permission, relevant only for unmanaged OIDC config"
-  type        = string
-  default     = null
 }
 
 variable "private_subnet_ids" {

--- a/rosa_sts_managed_oidc_no_modules/vpc.tf
+++ b/rosa_sts_managed_oidc_no_modules/vpc.tf
@@ -6,7 +6,7 @@ module "vpc" {
   name  = var.vpc_name
   cidr  = var.vpc_cidr_block
 
-  azs             = var.availability_zones
+  azs             = local.region_azs
   private_subnets = var.private_subnet_cidrs
   public_subnets  = var.public_subnet_cidrs
 

--- a/rosa_sts_managed_oidc_with_cognito_idp/.terraform.tfstate.lock.info
+++ b/rosa_sts_managed_oidc_with_cognito_idp/.terraform.tfstate.lock.info
@@ -1,1 +1,0 @@
-{"ID":"756182b9-4cb0-c0f7-8d33-53019664b593","Operation":"OperationTypeApply","Info":"","Who":"arepton@arepton-mac","Version":"1.5.7","Created":"2023-11-29T16:56:12.722236Z","Path":"terraform.tfstate"}

--- a/rosa_sts_managed_oidc_with_cognito_idp/cognito.tf
+++ b/rosa_sts_managed_oidc_with_cognito_idp/cognito.tf
@@ -7,7 +7,7 @@ resource "aws_cognito_user_pool" "cluster-idp" {
 }
 
 resource "aws_cognito_user_pool_domain" "domain" {
-  domain       = var.cluster_name
+  domain       = local.cluster_name
   user_pool_id = aws_cognito_user_pool.cluster-idp.id
 }
 

--- a/rosa_sts_managed_oidc_with_cognito_idp/variables.tf
+++ b/rosa_sts_managed_oidc_with_cognito_idp/variables.tf
@@ -44,7 +44,6 @@ variable "create_operator_roles" {
 variable "create_vpc" {
   type        = bool
   description = "Create custom VPC for ROSA cluster"
-  default     = true
 }
 
 variable "managed_oidc" {
@@ -57,12 +56,7 @@ variable "managed_oidc" {
 variable "cluster_name" {
   type        = string
   description = "The name of the ROSA cluster to create"
-  default     = "mobb-tf"
-
-  validation {
-    condition     = can(regex("^[a-z][-a-z0-9]{0,13}[a-z0-9]$", var.cluster_name))
-    error_message = "ROSA cluster name must be less than 16 characters, be lower case alphanumeric, with only hyphens."
-  }
+  default     = null
 }
 
 variable "additional_tags" {
@@ -168,6 +162,7 @@ variable "single_nat_gateway" {
 #AWS Info
 variable "aws_region" {
   type    = string
+  default = "us-east-2"
 }
 
 variable "rosa_admin_email" {

--- a/rosa_sts_unmanaged_oidc/main.tf
+++ b/rosa_sts_unmanaged_oidc/main.tf
@@ -17,17 +17,24 @@
 data "aws_availability_zones" "available" {}
 
 locals {
-  # Extract availability zone names for the specified region
-  region_azs = [for zone in data.aws_availability_zones.available.names : format("%s", zone)]
+  # Extract availability zone names for the specified region, limited to 3
+  region_azs = slice([for zone in data.aws_availability_zones.available.names : format("%s", zone)], 0, 3)
+  # If cluster_name is not null, use that, otherwise generate a random cluster name
+  cluster_name = coalesce(var.cluster_name, "rosa-${random_string.random_name.result}")
 }
 
+resource "random_string" "random_name" {
+  length           = 6
+  special          = false
+  upper            = false
+}
 
 # Create the VPC if it is wanted
 module "vpc" {
   create_vpc           = var.create_vpc
   source               = "../modules/network"
   aws_region           = var.aws_region
-  vpc_name             = "${var.cluster_name}_vpc"
+  vpc_name             = "${local.cluster_name}_vpc"
   additional_tags      = var.additional_tags
   vpc_cidr_block       = var.vpc_cidr_block
   availability_zones   = local.region_azs
@@ -40,7 +47,7 @@ module "vpc" {
 module "account_role" {
   create_account_roles   = var.create_account_roles
   source                 = "../modules/account_roles"
-  account_role_prefix    = var.cluster_name
+  account_role_prefix    = local.cluster_name
   path                   = var.path
   rosa_openshift_version = var.rosa_openshift_version
   account_role_policies  = var.account_role_policies
@@ -62,14 +69,14 @@ data "aws_caller_identity" "current" {
 # Use the Managed OpenShift Installer Role to create the unmanaged OIDC provider
 locals {
   path = coalesce(var.path, "/")
-  installer_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${local.path}${var.cluster_name}-Installer-Role"
+  installer_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${local.path}${local.cluster_name}-Installer-Role"
 }
 
 # Create unmanaged OIDC config
 module "oidc_provider" {
   source               = "../modules/unmanaged_oidc_provider"
-  operator_role_prefix = var.cluster_name
-  account_role_prefix  = var.cluster_name
+  operator_role_prefix = local.cluster_name
+  account_role_prefix  = local.cluster_name
   additional_tags      = var.additional_tags
   path                 = var.path
   installer_role_arn   = local.installer_role_arn
@@ -85,20 +92,20 @@ module "operator_roles" {
   source               = "../modules/operator_roles"
   oidc_thumbprint       = module.oidc_provider.thumbprint
   oidc_endpoint_url     = module.oidc_provider.oidc_endpoint_url
-  operator_role_prefix = var.cluster_name
+  operator_role_prefix = local.cluster_name
   additional_tags      = var.additional_tags
 }
 
 # Make the ROSA Cluster
 module "rosa_cluster" {
   source                 = "../modules/rosa_cluster"
-  cluster_name           = var.cluster_name
+  cluster_name           = local.cluster_name
   rosa_openshift_version = var.rosa_openshift_version
   aws_region             = var.aws_region
   multi_az               = var.multi_az
   availability_zones     = local.region_azs
-  account_role_prefix    = var.cluster_name
-  operator_role_prefix   = var.cluster_name
+  account_role_prefix    = local.cluster_name
+  operator_role_prefix   = local.cluster_name
   machine_type           = var.machine_type
   proxy                  = var.proxy
   worker_node_replicas   = var.worker_node_replicas

--- a/rosa_sts_unmanaged_oidc/main.tf
+++ b/rosa_sts_unmanaged_oidc/main.tf
@@ -14,15 +14,23 @@
 # limitations under the License.
 #
 
+data "aws_availability_zones" "available" {}
+
+locals {
+  # Extract availability zone names for the specified region
+  region_azs = [for zone in data.aws_availability_zones.available.names : format("%s", zone)]
+}
+
+
 # Create the VPC if it is wanted
 module "vpc" {
   create_vpc           = var.create_vpc
   source               = "../modules/network"
   aws_region           = var.aws_region
-  vpc_name             = var.vpc_name
+  vpc_name             = "${var.cluster_name}_vpc"
   additional_tags      = var.additional_tags
   vpc_cidr_block       = var.vpc_cidr_block
-  availability_zones   = var.availability_zones
+  availability_zones   = local.region_azs
   private_subnet_cidrs = var.private_subnet_cidrs
   public_subnet_cidrs  = var.public_subnet_cidrs
   single_nat_gateway   = var.single_nat_gateway
@@ -32,7 +40,7 @@ module "vpc" {
 module "account_role" {
   create_account_roles   = var.create_account_roles
   source                 = "../modules/account_roles"
-  account_role_prefix    = var.account_role_prefix
+  account_role_prefix    = var.cluster_name
   path                   = var.path
   rosa_openshift_version = var.rosa_openshift_version
   account_role_policies  = var.account_role_policies
@@ -54,14 +62,14 @@ data "aws_caller_identity" "current" {
 # Use the Managed OpenShift Installer Role to create the unmanaged OIDC provider
 locals {
   path = coalesce(var.path, "/")
-  installer_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${local.path}${var.account_role_prefix}-Installer-Role"
+  installer_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role${local.path}${var.cluster_name}-Installer-Role"
 }
 
 # Create unmanaged OIDC config
 module "oidc_provider" {
   source               = "../modules/unmanaged_oidc_provider"
-  operator_role_prefix = var.operator_role_prefix
-  account_role_prefix  = var.account_role_prefix
+  operator_role_prefix = var.cluster_name
+  account_role_prefix  = var.cluster_name
   additional_tags      = var.additional_tags
   path                 = var.path
   installer_role_arn   = local.installer_role_arn
@@ -77,7 +85,7 @@ module "operator_roles" {
   source               = "../modules/operator_roles"
   oidc_thumbprint       = module.oidc_provider.thumbprint
   oidc_endpoint_url     = module.oidc_provider.oidc_endpoint_url
-  operator_role_prefix = var.operator_role_prefix
+  operator_role_prefix = var.cluster_name
   additional_tags      = var.additional_tags
 }
 
@@ -88,21 +96,20 @@ module "rosa_cluster" {
   rosa_openshift_version = var.rosa_openshift_version
   aws_region             = var.aws_region
   multi_az               = var.multi_az
-  availability_zones     = var.availability_zones
-  account_role_prefix    = var.account_role_prefix
-  operator_role_prefix   = var.operator_role_prefix
+  availability_zones     = local.region_azs
+  account_role_prefix    = var.cluster_name
+  operator_role_prefix   = var.cluster_name
   machine_type           = var.machine_type
   proxy                  = var.proxy
+  worker_node_replicas   = var.worker_node_replicas
   autoscaling_enabled    = var.autoscaling_enabled
-  min_replicas           = var.min_replicas
-  max_replicas           = var.max_replicas
   oidc_config_id         = module.oidc_provider.id
   additional_tags        = var.additional_tags
   vpc_cidr_block         = var.vpc_cidr_block
 
   #private link cluster values
-  enable_private_link = var.enable_private_link
-  aws_subnet_ids   = var.create_vpc ? module.vpc.private_subnets : var.aws_subnet_ids
+  enable_private_link = var.private_cluster
+  aws_subnet_ids      = var.create_vpc ? concat(module.vpc.public_subnets, module.vpc.private_subnets) : var.aws_subnet_ids
 
   depends_on = [time_sleep.wait_10_seconds]
 }

--- a/rosa_sts_unmanaged_oidc/variables.tf
+++ b/rosa_sts_unmanaged_oidc/variables.tf
@@ -50,11 +50,7 @@ variable "create_vpc" {
 variable "cluster_name" {
   type        = string
   description = "The name of the ROSA cluster to create"
-
-  validation {
-    condition     = can(regex("^[a-z][-a-z0-9]{0,13}[a-z0-9]$", var.cluster_name))
-    error_message = "ROSA cluster name must be less than 16 characters, be lower case alphanumeric, with only hyphens."
-  }
+  default     = null
 }
 
 variable "additional_tags" {
@@ -160,4 +156,5 @@ variable "single_nat_gateway" {
 #AWS Info
 variable "aws_region" {
   type    = string
+  default = "eu-west-1"
 }

--- a/rosa_sts_unmanaged_oidc/variables.tf
+++ b/rosa_sts_unmanaged_oidc/variables.tf
@@ -1,13 +1,7 @@
 variable "rosa_openshift_version" {
   type        = string
-  default     = "4.13"
+  default     = "4.14.2"
   description = "Desired version of OpenShift for the cluster, for example '4.1.0'. If version is greater than the currently running version, an upgrade will be scheduled."
-}
-
-# Account Roles
-variable "account_role_prefix" {
-  type    = string
-  default = "mobb"
 }
 
 variable "account_role_policies" {
@@ -19,12 +13,6 @@ variable "account_role_policies" {
     sts_instance_controlplane_permission_policy = string
   })
   default = null
-}
-
-# Operator Roles
-variable "operator_role_prefix" {
-  type    = string
-  default = "mobbtf"
 }
 
 variable "operator_role_policies" {
@@ -44,37 +32,18 @@ variable "operator_role_policies" {
 variable "create_account_roles" {
   type        = bool
   description = "Create cluster wide accounts roles"
-  default     = false
+  default     = true
 }
 
 variable "create_operator_roles" {
   type        = bool
   description = "Create cluster wide operator roles"
-  default     = false
+  default     = true
 }
 
 variable "create_vpc" {
   type        = bool
   description = "Create custom VPC for ROSA cluster"
-  default     = false
-}
-
-variable "managed_oidc" {
-  type        = bool
-  description = "Red Hat managed or unmanaged (Customer hosted) OIDC Configuration"
-  default     = true
-}
-
-variable "create_aad_app" {
-  type        = bool
-  description = "Create a Azure AD app for ROSA cluster idp"
-  default     = false
-}
-
-variable "create_idp_aad" {
-  type        = bool
-  description = "Create Azure AD IDP for ROSA cluster"
-  default     = false
 }
 
 # ROSA Cluster info
@@ -107,16 +76,17 @@ variable "path" {
 variable "multi_az" {
   type        = bool
   description = "Multi AZ Cluster for High Availability"
-  default     = false
+  default     = true
 }
 
 variable "machine_type" {
   description = "The AWS instance type that used for the instances creation ."
   type        = string
+  default     = "m5.xlarge"
 }
 
 variable "worker_node_replicas" {
-  default     = null
+  default     = 3
   description = "Number of worker nodes to provision. Single zone clusters need at least 2 nodes, multizone clusters need at least 3 nodes"
   type        = number
 }
@@ -131,13 +101,13 @@ variable "autoscaling_enabled" {
 variable "min_replicas" {
   description = "The minimum number of replicas for autoscaling."
   type        = number
-  default     = null
+  default     = 3
 }
 
 variable "max_replicas" {
   description = "The maximum number of replicas not exceeded by the autoscaling functionality."
   type        = number
-  default     = null
+  default     = 3
 }
 
 variable "proxy" {
@@ -152,17 +122,9 @@ variable "proxy" {
 }
 
 #Private link cluster Info
-variable "enable_private_link" {
+variable "private_cluster" {
   type        = bool
-  description = "This enables private link"
-  default     = false
-}
-
-#VPC Info
-variable "vpc_name" {
-  type        = string
-  description = "VPC Name"
-  default     = "mobb-tf-vpc"
+  description = "Do you want this cluster to be private? true or false"
 }
 
 variable "vpc_cidr_block" {
@@ -198,61 +160,4 @@ variable "single_nat_gateway" {
 #AWS Info
 variable "aws_region" {
   type    = string
-  default = "us-east-2"
-}
-
-variable "availability_zones" {
-  type        = list(any)
-  description = "The availability zones to use for the cluster"
-  default     = ["us-east-2a", "us-east-2b", "us-east-2c"]
-}
-
-#Azure AD config
-variable "aad_app_name" {
-  type        = string
-  default     = "kumudu-tf-test-app"
-  description = "Azure AD App Name"
-}
-
-variable "aad_app_password_name" {
-  type        = string
-  default     = "kh-ROSA-Secret"
-  description = "AAD Secret Name"
-}
-
-variable "aad_app_redirect_uri" {
-  type        = string
-  default     = "https://oauth-openshift.apps.iv2wbc7f.westus2.aroapp.io/oauth2callback/AAD"
-  description = "AAD App Redirect_uri"
-}
-
-variable "aad_location" {
-  type        = string
-  default     = "eastus"
-  description = "Azure region"
-}
-
-#IDP
-variable "idp_name" {
-  type    = string
-  default = "AAD"
-}
-
-variable "aad_client_id" {
-  description = "Azure Application (client) ID"
-  default     = "known"
-  type        = string
-}
-
-variable "aad_client_secret" {
-  description = "Azure Client credentials"
-  default     = "known"
-  type        = string
-  sensitive   = true
-}
-
-variable "aad_tenant_id" {
-  description = "Azure Directory (tenant) ID"
-  type        = string
-  sensitive   = true
 }


### PR DESCRIPTION
- Better README
- Removal of operator role prefix, it is now set to be the cluster name. This is to simplify the variables needed for users.
- Removal of account role prefix, it is now set to be the cluster name. This is to simplify the variables needed for users.
- A consistent experience across all terraform plans, they now will only ask for input if you would like to create a VPC and if you would like the cluster to be private or not
- Improved example tfvars files are now in the README
- var.cluster_name has been replaced with local.cluster_name, and if you do not provide a cluster_name it will now generate one for you in the format rosa-$random_5_digit_string. This helps for users who want to make multiple clusters automatically, and also removes another input needed for people getting started
- Removed the availability_zones variable and replaced it to automatically select three availability_zones based on the region provided, to remove another variable needed from the user
- Removed the ability to make single zone clusters as this adds a lot of complexity to the terraform plans. For users wanting to do this they can either write the tf code themselves or use the rosa command
